### PR TITLE
fix: prevent event propagation on airport removal in TripSelection

### DIFF
--- a/src/components/TripSelection.tsx
+++ b/src/components/TripSelection.tsx
@@ -376,9 +376,11 @@ export default function TripSelection({ predefinedTrips }: TripSelectionProps) {
 																				{airport.code} - {airport.city}
 																				<X
 																					className="h-3 w-3 cursor-pointer hover:text-destructive"
-																					onClick={() =>
-																						removeAirport(airport.code)
-																					}
+																					onClick={(e) => {
+																						e.preventDefault();
+																						e.stopPropagation();
+																						removeAirport(airport.code);
+																					}}
 																				/>
 																			</Badge>
 																		))}


### PR DESCRIPTION
## Summary
- Fixes issue where clicking the remove icon on an airport badge also triggered parent click events
- Adds event.preventDefault() and event.stopPropagation() to the removeAirport click handler

## Changes

### TripSelection Component
- Updated the onClick handler for the remove icon (`X`) on airport badges
- Prevents default behavior and stops event propagation before calling `removeAirport(airport.code)`

## Test plan
- [ ] Click the remove icon on an airport badge and verify only the airport is removed
- [ ] Ensure no unintended parent click handlers are triggered when removing an airport
- [ ] Test UI behavior remains consistent after removal

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/1f59ae4f-b357-44f0-bafb-8a511f8fdc3d